### PR TITLE
SPI Driver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,11 +30,13 @@ TARGET = lbj.hex
 ### Source Files ###
 APP_SOURCES = $(SOURCE_DIR)/main.c \
               $(SOURCE_DIR)/pin_avr.c \
+              $(SOURCE_DIR)/spi_avr.c \
               $(SOURCE_DIR)/controller.c \
               $(SOURCE_DIR)/bsp.c
 
 APP_HEADERS = $(HEADER_DIR)/controller.h \
               $(HEADER_DIR)/pin.h \
+              $(HEADER_DIR)/spi.h \
               $(HEADER_DIR)/bsp.h
 
 APP_OBJECTS = $(addprefix $(BUILD_DIR)/,$(notdir $(APP_SOURCES:.c=.o)))

--- a/include/spi.h
+++ b/include/spi.h
@@ -1,0 +1,55 @@
+/**
+ * @file   spi.h
+ * @brief  This file contains the SPI driver declaration.
+ * @author Liam Bucci <liam.bucci@gmail.com>
+ * @date   2015-08-29
+ * @copyright
+ * {
+ *     Copyright 2015 Liam Bucci
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ * }
+ */
+
+#ifndef SPI_H
+#define SPI_H
+
+#include <stdbool.h>
+#include "pin.h"
+
+typedef enum spi_baud_
+{
+    SPI_BAUD_100K = 0U,
+    SPI_BAUD_200K = 1U,
+    SPI_BAUD_500K = 2U,
+    SPI_BAUD_1M   = 3U
+} spi_baud_t;
+
+typedef struct spi_
+{
+    spi_baud_t baudrate;
+    pin_t cs;
+    pin_t mosi;
+    pin_t miso;
+    pin_t sclk;
+
+} spi_t;
+
+bool spi_init( spi_t * const spi );
+bool spi_enable_cs( spi_t * const spi );
+bool spi_disable_cs( spi_t * const spi );
+bool spi_write_read( spi_t * const spi, char * const read_byte, const char write_byte );
+bool spi_write( spi_t * const spi, const char write_byte );
+bool spi_read( spi_t * const spi, char * const read_byte );
+
+#endif /* SPI_H */

--- a/source/main.c
+++ b/source/main.c
@@ -27,6 +27,7 @@
 #include <util/delay.h>
 
 #include "pin.h"
+#include "spi.h"
 #include "controller.h"
 
 
@@ -36,15 +37,46 @@ int main( int argc, char *argv[] )
 	//char minor_version = LBJ_MINOR_VERSION;
 	//char patch_version = LBJ_PATCH_VERSION;
 
-	pin_t led = { PIN_BANK_B, PIN_NUM_3, false };
+    spi_t spi = {
+        SPI_BAUD_1M,
+        {
+            PIN_BANK_B,
+            PIN_NUM_3,
+            true
+        },
+        {
+            PIN_BANK_B,
+            PIN_NUM_1,
+            false
+        },
+        {
+            PIN_BANK_B,
+            PIN_NUM_0,
+            false
+        },
+        {
+            PIN_BANK_B,
+            PIN_NUM_2,
+            false
+        }
+    };
 
-    (void)pin_set_mode( &led, PIN_MODE_OUTPUT );
+    (void)spi_init( &spi );
 
     while(1)
     {
-        (void)pin_assert( &led );
-        _delay_ms(300);
-        (void)pin_deassert( &led );
+        (void)spi_enable_cs( &spi );
+        (void)spi_write( &spi, 'l' );
+        (void)spi_disable_cs( &spi );
+        (void)spi_enable_cs( &spi );
+        (void)spi_write( &spi, 'i' );
+        (void)spi_disable_cs( &spi );
+        (void)spi_enable_cs( &spi );
+        (void)spi_write( &spi, 'a' );
+        (void)spi_disable_cs( &spi );
+        (void)spi_enable_cs( &spi );
+        (void)spi_write( &spi, 'm' );
+        (void)spi_disable_cs( &spi );
         _delay_ms(300);
     }
 

--- a/source/spi_avr.c
+++ b/source/spi_avr.c
@@ -1,0 +1,136 @@
+/**
+ * @file   spi_avr.c
+ * @brief  This file contains the AVR spi driver implementation.
+ * @author Liam Bucci <liam.bucci@gmail.com>
+ * @date   2015-08-29
+ * @copyright
+ * {
+ *     Copyright 2015 Liam Bucci
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ * }
+ */
+
+#include <stddef.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <avr/io.h>
+#include "spi.h"
+
+/* API Function Definitions ==================================================================== */
+
+bool spi_init( spi_t * const spi )
+{
+    bool retval = false;
+
+    if( spi != NULL )
+    {
+        /* Initialize CS pin */
+        retval = pin_set_mode( &(spi->cs), PIN_MODE_OUTPUT );
+        retval = pin_deassert( &(spi->cs) ) && retval;
+
+        /* Initialize MOSI pin */
+        if( retval == true )
+        {
+            retval = pin_set_mode( &(spi->mosi), PIN_MODE_OUTPUT );
+            retval = pin_deassert( &(spi->mosi) ) && retval;
+        }
+
+        /* Initialize MISO pin */
+        if( retval == true )
+        {
+            retval = pin_set_mode( &(spi->miso), PIN_MODE_INPUT );
+        }
+
+        /* Initialize SCLK pin */
+        if( retval == true )
+        {
+            retval = pin_set_mode( &(spi->sclk), PIN_MODE_OUTPUT );
+            retval = pin_deassert( &(spi->sclk) ) && retval;
+        }
+
+        /* Initialize USI registers */
+        if( retval == true )
+        {
+            /* Three-wire mode, USI software clock */
+            USICR = (USIWM0) | (USICLK);
+        }
+    }
+
+    return retval;
+}
+
+bool spi_enable_cs( spi_t * const spi )
+{
+    bool retval = false;
+
+    if( spi != NULL )
+    {
+        /* Assert CS pin */
+        retval = pin_assert( &(spi->cs) );
+    }
+
+    return retval;
+}
+
+bool spi_disable_cs( spi_t * const spi )
+{
+    bool retval = false;
+
+    if( spi != NULL )
+    {
+        /* Deassert CS pin */
+        retval = pin_deassert( &(spi->cs) );
+    }
+
+    return retval;
+}
+
+bool spi_write_read( spi_t * const spi, char * const read_byte, const char write_byte )
+{
+    bool retval = false;
+    //pin_t led = { PIN_BANK_B, PIN_NUM_3, false };
+
+    if( (spi != NULL) &&
+        (read_byte != NULL) )
+    {
+
+        /* Write byte to USI register */
+        USIDR = write_byte;
+
+        /* Clear 4-bit counter and overflow flag */
+        USISR = (1<<USIOIF);
+
+        while( (USISR & (1<<USIOIF)) == 0 )
+        {
+            /* Strobe clock and shift next bit out */
+            USICR = (1<<USIWM0) | (1<<USICS1) | (1<<USICLK) | (1<<USITC);
+        }
+
+        *read_byte = USIDR;
+    }
+
+    return retval;
+}
+
+bool spi_write( spi_t * const spi, const char write_byte )
+{
+    char dummy_read;
+
+    return spi_write_read( spi, &dummy_read, write_byte );
+}
+
+bool spi_read( spi_t * const spi, char * const read_byte )
+{
+    return spi_write_read( spi, read_byte, 0U );
+}


### PR DESCRIPTION
- Added an SPI driver. Sends SPI data in mode CPOL=1, CPHA=1 (compatible
  with the TLC591x).
- Tested by sending data and reading with a Saleae Logic analyzer.
