### PR TITLE
TLC591x Driver and bug fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,12 +31,14 @@ TARGET = lbj.hex
 APP_SOURCES = $(SOURCE_DIR)/main.c \
               $(SOURCE_DIR)/pin_avr.c \
               $(SOURCE_DIR)/spi_avr.c \
+              $(SOURCE_DIR)/tlc591x_avr.c \
               $(SOURCE_DIR)/controller.c \
               $(SOURCE_DIR)/bsp.c
 
 APP_HEADERS = $(HEADER_DIR)/controller.h \
               $(HEADER_DIR)/pin.h \
               $(HEADER_DIR)/spi.h \
+              $(HEADER_DIR)/tlc591x.h \
               $(HEADER_DIR)/bsp.h
 
 APP_OBJECTS = $(addprefix $(BUILD_DIR)/,$(notdir $(APP_SOURCES:.c=.o)))

--- a/include/tlc591x.h
+++ b/include/tlc591x.h
@@ -1,0 +1,42 @@
+/**
+ * @file   tlc591x.h
+ * @brief  This file contains the TLC591x driver declaration.
+ * @author Liam Bucci <liam.bucci@gmail.com>
+ * @date   2015-08-29
+ * @copyright
+ * {
+ *     Copyright 2015 Liam Bucci
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ * }
+ */
+
+#ifndef TLC591x_H
+#define TLC591x_H
+
+#include <stdint.h>
+#include "spi.h"
+
+typedef struct tlc591x_s
+{
+    spi_t spi;
+    pin_t le;
+    pin_t oe_;
+} tlc591x_t;
+
+bool tlc591x_init( tlc591x_t * const tlc );
+bool tlc591x_enable_output( tlc591x_t * const tlc );
+bool tlc591x_disable_output( tlc591x_t * const tlc );
+bool tlc591x_write_values( tlc591x_t * const tlc, const uint8_t values );
+
+#endif // TLC591x_H

--- a/source/main.c
+++ b/source/main.c
@@ -28,11 +28,13 @@
 
 #include "pin.h"
 #include "spi.h"
+#include "tlc591x.h"
 #include "controller.h"
 
 
 int main( int argc, char *argv[] )
 {
+    uint8_t output = 0;
 	//char major_version = LBJ_MAJOR_VERSION;
 	//char minor_version = LBJ_MINOR_VERSION;
 	//char patch_version = LBJ_PATCH_VERSION;
@@ -61,23 +63,21 @@ int main( int argc, char *argv[] )
         }
     };
 
-    (void)spi_init( &spi );
+    tlc591x_t tlc = {
+        spi,
+        { PIN_BANK_B, PIN_NUM_4, false },
+        { PIN_BANK_B, PIN_NUM_3, true }
+    };
+
+    (void)tlc591x_init( &tlc );
+    (void)tlc591x_enable_output( &tlc );
 
     while(1)
     {
-        (void)spi_enable_cs( &spi );
-        (void)spi_write( &spi, 'l' );
-        (void)spi_disable_cs( &spi );
-        (void)spi_enable_cs( &spi );
-        (void)spi_write( &spi, 'i' );
-        (void)spi_disable_cs( &spi );
-        (void)spi_enable_cs( &spi );
-        (void)spi_write( &spi, 'a' );
-        (void)spi_disable_cs( &spi );
-        (void)spi_enable_cs( &spi );
-        (void)spi_write( &spi, 'm' );
-        (void)spi_disable_cs( &spi );
-        _delay_ms(300);
+        (void)tlc591x_write_values( &tlc, output );
+        output++;
+        output = output % 16;
+        _delay_ms(500);
     }
 
 	return 0;

--- a/source/spi_avr.c
+++ b/source/spi_avr.c
@@ -63,7 +63,7 @@ bool spi_init( spi_t * const spi )
         if( retval == true )
         {
             /* Three-wire mode, USI software clock */
-            USICR = (USIWM0) | (USICLK);
+            USICR = (1<<USIWM0) | (1<<USICLK);
         }
     }
 
@@ -99,7 +99,6 @@ bool spi_disable_cs( spi_t * const spi )
 bool spi_write_read( spi_t * const spi, char * const read_byte, const char write_byte )
 {
     bool retval = false;
-    //pin_t led = { PIN_BANK_B, PIN_NUM_3, false };
 
     if( (spi != NULL) &&
         (read_byte != NULL) )
@@ -118,6 +117,8 @@ bool spi_write_read( spi_t * const spi, char * const read_byte, const char write
         }
 
         *read_byte = USIDR;
+
+        retval = true;
     }
 
     return retval;

--- a/source/tlc591x_avr.c
+++ b/source/tlc591x_avr.c
@@ -1,0 +1,96 @@
+/**
+ * @file   tlc591x_avr.c
+ * @brief  This file contains the TLC591x driver implementation for the AVR.
+ * @author Liam Bucci <liam.bucci@gmail.com>
+ * @date   2015-08-29
+ * @copyright
+ * {
+ *     Copyright 2015 Liam Bucci
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ * }
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+#include "spi.h"
+#include "tlc591x.h"
+
+bool tlc591x_init( tlc591x_t * const tlc )
+{
+    bool retval = false;
+
+    if( tlc != NULL )
+    {
+        /* Initialize SPI device */
+        retval = spi_init( &(tlc->spi) );
+
+        /* Initialize LE pin */
+        if( retval == true )
+        {
+            retval = pin_set_mode( &(tlc->le), PIN_MODE_OUTPUT );
+            retval = pin_deassert( &(tlc->le) ) && retval;
+        }
+
+        /* Initialize nOE pin */
+        if( retval == true )
+        {
+            retval = pin_set_mode( &(tlc->oe_), PIN_MODE_OUTPUT );
+            retval = pin_deassert( &(tlc->oe_) ) && retval;
+        }
+    }
+
+    return retval;
+}
+
+bool tlc591x_enable_output( tlc591x_t * const tlc )
+{
+    bool retval = false;
+
+    if( tlc != NULL )
+    {
+        retval = pin_assert( &(tlc->oe_) );
+    }
+
+    return retval;
+}
+
+bool tlc591x_disable_output( tlc591x_t * const tlc )
+{
+    bool retval = false;
+
+    if( tlc != NULL )
+    {
+        retval = pin_deassert( &(tlc->oe_) );
+    }
+
+    return retval;
+}
+
+bool tlc591x_write_values( tlc591x_t * const tlc, const uint8_t values )
+{
+    bool retval = false;
+
+    if( tlc != NULL )
+    {
+        retval = spi_write( &(tlc->spi), values );
+
+        if( retval == true )
+        {
+            retval = pin_assert( &(tlc->le) );
+            retval = pin_deassert( &(tlc->le) ) && retval;
+        }
+    }
+
+    return retval;
+}


### PR DESCRIPTION
- Added a TLC591x driver which uses the SPI driver to send output values
  to the TLC591x chip. Controls the LE and !OE lines as necessary.
- Bug fixes in the SPI driver:
  - Return value wasn't correct.
  - Initial register value wasn't correct.
